### PR TITLE
Parse and merge headline tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,4 +266,55 @@ If you find this work useful, please consider citing our papers:
 }
  ```
 
+# Headline标签修复解决方案
+
+## 问题描述
+
+需要处理两种Headline标签情况：
+1. `<Headline[^>]*>(.*?)</Headline>` - 完整标签
+2. `<Headline[^>]*>(.*?)</Headline` - 缺少结束 `>` 的不完整标签
+
+原始方法使用两个正则表达式分别匹配，但存在贪婪匹配导致的问题。
+
+## 解决方案
+
+采用精确匹配策略：
+
+1. **查找开始标签**：使用 `<Headline[^>]*>` 找到所有开始标签
+2. **逐个匹配结束标签**：对每个开始标签，查找最近的结束标签
+3. **判断完整性**：检查结束标签是否包含 `>`
+4. **修复不完整标签**：在缺少 `>` 的位置添加
+
+## 使用方法
+
+```python
+from final_headline_fix import process_text
+
+# 处理文本
+text = """<Headline Icon="Test">标题</Headline 不完整标签"""
+fixed_text = process_text(text)
+print(fixed_text)  # <Headline Icon="Test">标题</Headline> 不完整标签
+```
+
+## 核心函数
+
+### `fix_headline_tags_precise(text)`
+- 输入：包含Headline标签的文本
+- 输出：修复后的文本和匹配结果列表
+- 功能：精确识别和修复不完整的Headline标签
+
+### `process_text(text)`
+- 简化接口，只返回修复后的文本
+
+## 测试结果
+
+✅ 正确处理完整标签  
+✅ 正确识别和修复不完整标签  
+✅ 避免贪婪匹配问题  
+✅ 处理混合情况  
+
+## 文件说明
+
+- `final_headline_fix.py` - 主要实现文件，包含完整的解决方案和测试用例
+
 

--- a/final_headline_fix.py
+++ b/final_headline_fix.py
@@ -1,0 +1,137 @@
+import re
+
+def fix_headline_tags_precise(text):
+    """
+    精确修复Headline标签的解决方案
+    
+    策略：
+    1. 首先查找所有的开始标签 <Headline...>
+    2. 对每个开始标签，查找最近的结束标签
+    3. 判断结束标签是完整的还是不完整的
+    4. 修复不完整的标签
+    """
+    
+    # 查找所有开始标签
+    start_pattern = r'<Headline[^>]*>'
+    start_matches = list(re.finditer(start_pattern, text, flags=re.IGNORECASE))
+    
+    print(f"找到 {len(start_matches)} 个开始标签")
+    
+    results = []
+    
+    for i, start_match in enumerate(start_matches):
+        start_pos = start_match.start()
+        start_end = start_match.end()
+        
+        # 从开始标签后面查找结束标签
+        remaining_text = text[start_end:]
+        
+        # 查找 </Headline> 或 </Headline
+        end_pattern = r'(.*?)</Headline(>?)'
+        end_match = re.search(end_pattern, remaining_text, flags=re.IGNORECASE | re.DOTALL)
+        
+        if end_match:
+            content = end_match.group(1)
+            has_closing_bracket = end_match.group(2) == '>'
+            
+            # 计算绝对位置
+            content_start = start_end
+            content_end = start_end + end_match.start(2) + (1 if has_closing_bracket else 0)
+            full_end = start_end + end_match.end()
+            
+            result = {
+                'start': start_pos,
+                'end': full_end,
+                'content': content.strip(),
+                'type': 'complete' if has_closing_bracket else 'incomplete',
+                'needs_fix': not has_closing_bracket,
+                'full_match': text[start_pos:full_end]
+            }
+            
+            results.append(result)
+            
+            print(f"  {i+1}. [{result['type']}] 位置({result['start']}, {result['end']})")
+            print(f"     内容: {repr(result['content'][:50])}...")
+            print(f"     需要修复: {result['needs_fix']}")
+        else:
+            print(f"  {i+1}. 未找到对应的结束标签")
+    
+    # 修复不完整的标签
+    fixed_text = text
+    fix_count = 0
+    
+    # 从后往前修复，避免位置偏移
+    for result in reversed(results):
+        if result['needs_fix']:
+            # 在结束位置添加 '>'
+            end_pos = result['end']
+            fixed_text = fixed_text[:end_pos] + '>' + fixed_text[end_pos:]
+            fix_count += 1
+            print(f"  修复位置 {end_pos}: 添加了 '>'")
+    
+    print(f"\n总共修复了 {fix_count} 个不完整标签")
+    
+    return fixed_text, results
+
+def test_precise_fix():
+    """测试精确修复功能"""
+    
+    # 测试用例1: 包含不完整标签
+    test1 = """<Headline Icon="Paraphrase">释义</Headline 
+用户可以自定义TE值。
+<Headline Icon="Paraphrase">释义</Headline>
+TE值自动设为最小。"""
+    
+    # 测试用例2: 第二个原始文本
+    test2 = """<Headline Icon="Explanation">解释 </Headline
+
+灰质成像可以检测到脱髓鞘病变。
+
+<Headline Icon="SupplementaryExplanation">补充说明</Headline>"""
+    
+    # 测试用例3: 混合情况
+    test3 = """<Headline Icon="Test1">标题1</Headline> 完整标签
+<Headline Icon="Test2">标题2</Headline 不完整标签  
+<Headline Icon="Test3">标题3</Headline> 又一个完整标签"""
+    
+    test_cases = [
+        ("测试用例1 - 包含不完整标签", test1),
+        ("测试用例2 - 第二个原始文本", test2), 
+        ("测试用例3 - 混合情况", test3)
+    ]
+    
+    for name, text in test_cases:
+        print("=" * 80)
+        print(f"{name}")
+        print("=" * 80)
+        
+        fixed_text, results = fix_headline_tags_precise(text)
+        
+        print(f"\n原始文本:\n{text}")
+        print(f"\n修复后文本:\n{fixed_text}")
+        print("\n" + "-" * 40)
+
+# 提供给用户使用的简化函数
+def process_text(text):
+    """
+    处理文本中的Headline标签
+    返回修复后的文本
+    """
+    fixed_text, _ = fix_headline_tags_precise(text)
+    return fixed_text
+
+if __name__ == "__main__":
+    test_precise_fix()
+    
+    print("\n" + "=" * 80)
+    print("使用原始测试数据:")
+    print("=" * 80)
+    
+    # 使用你提供的原始测试数据
+    original_t = """【TE模式】是指设置TE的方式。选项有：\n1.【自定义】\n<Headline Icon="Paraphrase">释义</Headline \n用户可以自定义TE值。\n2.【最小值】\n<Headline Icon="Paraphrase">释义</Headline>\nTE值自动设为最小。\n<Headline Icon="Application">使用场景</Headline>\n在需要较高信噪比、更低扫描时间的场景下使用，同时可以减轻搏动伪影的影响。"""
+    
+    print("处理原始测试数据...")
+    fixed_original, results = fix_headline_tags_precise(original_t)
+    
+    print(f"\n原始:\n{original_t}")
+    print(f"\n修复后:\n{fixed_original}")


### PR DESCRIPTION
Fixes the parsing and repair of `<Headline>` tags to correctly handle incomplete closing tags and prevent greedy regex matching.

Previous regex patterns struggled with greedy matching, leading to incorrect extraction of content between `<Headline>` tags, especially when the closing tag was malformed (e.g., `</Headline`). This PR implements a precise, two-step approach: first, all opening `<Headline>` tags are identified, then for each, its nearest corresponding closing tag is located and automatically corrected if it's missing the final `>`.

---

[Open in Web](https://cursor.com/agents?id=bc-ee1f3126-bcbb-46fa-a35c-618a02575e21) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ee1f3126-bcbb-46fa-a35c-618a02575e21) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)